### PR TITLE
Atualizando envio de informações na transação

### DIFF
--- a/includes/class-woocommerce-4all.php
+++ b/includes/class-woocommerce-4all.php
@@ -191,6 +191,46 @@
         ) );
       } // close init_form_fields
 
+      public function add_customer(){
+
+        $data = [];
+
+        if ($_REQUEST["billing_first_name"] && $_REQUEST["billing_last_name"]) {
+          $fullName = $_REQUEST["billing_first_name"] . ' ' . $_REQUEST["billing_last_name"];
+          $data["fullName"] = $fullName;
+        }
+
+        if ($_REQUEST["billing_address_1"]) {
+          $data["address"] = $_REQUEST["billing_address_1"];
+        }
+
+        if ($_REQUEST["billing_city"]) {
+          $data["city"] = $_REQUEST["billing_city"];
+        }
+
+        if ($_REQUEST["billing_state"]) {
+          $data["state"] = $_REQUEST["billing_state"];
+        }
+
+        if ($_REQUEST["billing_postcode"]) {
+          $data["zipCode"] = $_REQUEST["billing_postcode"];
+        }
+
+        if ($_REQUEST["billing_phone"]) {
+          $data["phoneNumber"] = $_REQUEST["billing_phone"];
+        }
+
+        if ($_REQUEST["billing_email"]) {
+          $data["emailAddress"] = $_REQUEST["billing_email"];
+        }
+
+        if (sizeof($data) > 0 ) {
+          return $data;
+        }
+
+        return null;
+      }
+
       /*
       * Try make the payment
       */
@@ -208,6 +248,8 @@
           "total" => (int)$order->get_total() * 100,
           "metaId" => "" . $order_id
           ];
+
+        $metaData["customer"] = $this->add_customer();
 
         $tryPay = $gateway_4all->paymentFlow($metaData);
 

--- a/includes/woocommerce-4all-gateway.php
+++ b/includes/woocommerce-4all-gateway.php
@@ -99,6 +99,19 @@
             ]],
           "autoCapture" => true
         );
+
+        if ($metaData["customer"]) {
+          $body["customerInfo"] = array(
+            "fullName" => $metaData["customer"]["fullName"],
+            "address" => $metaData["customer"]["address"],
+            "city" => $metaData["customer"]["city"],
+            "state" => $metaData["customer"]["state"],
+            "zipCode" => $metaData["customer"]["zipCode"],
+            "phoneNumber" => $metaData["customer"]["phoneNumber"],
+            "emailAddress" => $metaData["customer"]["emailAddress"]
+          );
+        }
+
         $response = $this->request('createTransaction', $body);
         if ($response["status"] !== 4) {
           if ($response["status"] === 0 || $response["status"] === 2 || $response["status"] === 3) {


### PR DESCRIPTION
Agora ao fazer uma transação, o pluguin busca dos campos padrões do woocommerce as informações do comprador e envia junto das informações do cartão ao tentar realizar de fato a transação.