### PR TITLE
Listagem de bandeiras

### DIFF
--- a/assets/css/frontend/4all-style.css
+++ b/assets/css/frontend/4all-style.css
@@ -1,0 +1,41 @@
+.payment_method_4all {
+
+}
+.payment_method_4all .form-row {
+  margin-bottom: 10px;
+}
+.payment_method_4all .form-row-installment {
+
+}
+.payment_method_4all .form-row-installment select {
+  border: 1px solid #DDD;
+  border-radius: 2px;
+  background: #f0f0f0;
+  display: inline-block;
+  width: auto;
+  cursor: pointer;
+  padding: 9px;
+  min-width: 50px;
+}
+.payment_method_4all .form-row-brands {
+  display: block;
+  overflow: hidden;
+  position: relative;
+  padding: 6px 0;
+}
+.payment_method_4all .form-row-brands img {
+  display: inline-block;
+  vertical-align: middle;
+  filter: grayscale(100%);
+  opacity: .5;
+  width: auto;
+  height: auto;
+}
+.payment_method_4all .form-row-brands img.active {
+  filter: grayscale(0);
+  opacity: 1;
+}
+#payment .payment_methods .payment_method_4all  .form-row-brands img {
+  float: none;
+  margin: 1px 4px;
+}

--- a/assets/css/frontend/4all-style.css
+++ b/assets/css/frontend/4all-style.css
@@ -39,3 +39,7 @@
   float: none;
   margin: 1px 4px;
 }
+
+#payment .payment_methods .payment_method_4all .alert {
+  border: 0.5px solid #ff0000;
+}

--- a/assets/css/frontend/4all-style.css
+++ b/assets/css/frontend/4all-style.css
@@ -43,3 +43,8 @@
 #payment .payment_methods .payment_method_4all .alert {
   border: 0.5px solid #ff0000;
 }
+
+#payment .payment_methods .payment_method_4all .disabled {
+  background-color: rgb(214, 214, 214);
+  cursor: not-allowed;
+}

--- a/assets/js/4all-scripts.js
+++ b/assets/js/4all-scripts.js
@@ -15,13 +15,15 @@ var $ = jQuery;
     var ids = $("#brandsList").val();
     ids = ids.split(";");
 
+    errorCardNumber = false;
+
     if (number.length === 0) {
       $brands.find('.active').removeClass('active');
       $('[name=cardNumber]').removeClass('alert');
-    } else if (/^4/.test(number) && ids.includes("0")) { //visa
+    } else if (/^4/.test(number) && ids.includes("0")) { //VISA
       $brands.find('#brand-' + 0).addClass('active').siblings().removeClass('active');
       $('[name=cardNumber]').removeClass('alert');
-    } else if (/^(222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720|5018|50[2-3]|506|5[6-8]|5|603689|639|6220|67)/.test(number) && ids.includes("1")) { //mastercard
+    } else if (/^(222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720|5018|50[2-3]|506|5[6-8]|5|603689|639|6220|67)/.test(number) && ids.includes("1")) { //MASTERCARD
       $brands.find('#brand-' + 1).addClass('active').siblings().removeClass('active');
       $('[name=cardNumber]').removeClass('alert');
     } else if (/^(36|301|305|309|3[8-9])/.test(number) && ids.includes("2")) { //DINERS
@@ -45,20 +47,21 @@ var $ = jQuery;
     } else if (/^(384100|384140|384160|60)/.test(number) && ids.includes("8")) { //HIPERCARD
       $brands.find('#brand-' + 8).addClass('active').siblings().removeClass('active');
       $('[name=cardNumber]').removeClass('alert');
-    } else if (/^6033/.test(number) && ids.includes("11")) { //TICKET
-      $brands.find('#brand-' + 11).addClass('active').siblings().removeClass('active');
-      $('[name=cardNumber]').removeClass('alert');
-    } else if (/^6026/.test(number) && ids.includes("11")) { //TICKET
-      $brands.find('#brand-' + 11).addClass('active').siblings().removeClass('active');
-      $('[name=cardNumber]').removeClass('alert');
-    } else if (number.length > 11) {
-      $brands.find('.active').removeClass('active');
+    } else {
+      errorCardNumber = true;
+    }
+  }
+
+  function validateCard(){
+    if (errorCardNumber) {
+      $('.form-row-brands').find('.active').removeClass('active');
       $('[name=cardNumber]').addClass('alert');
     }
   }
 
   var expirationSelector = '.payment_method_4all [name=expirationDate]';
   var cardNumberSelector = '.payment_method_4all [name=cardNumber]';
+  var errorCardNumber = false;
 
   $context.on('keypress', expirationSelector, function(event) {
     var v = destroyMask(event.target.value);
@@ -68,6 +71,10 @@ var $ = jQuery;
   $context.on('keyup', cardNumberSelector, function (event) {
     var v = event.target.value;
     checkCardType(v, $('.form-row-brands'));
+  });
+
+  $context.on('focusout', cardNumberSelector, function () {
+    validateCard();
   });
 
 }(jQuery));

--- a/assets/js/4all-scripts.js
+++ b/assets/js/4all-scripts.js
@@ -12,11 +12,49 @@ var $ = jQuery;
   }
 
   function checkCardType(number, $brands) {
+    var ids = $("#brandsList").val();
+    ids = ids.split(";");
 
-
-    var id = 1;   
-
-    $brands.find('#brand-' + id).addClass('active').siblings().removeClass('active');
+    if (number.length === 0) {
+      $brands.find('.active').removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^4/.test(number) && ids.includes("0")) { //visa
+      $brands.find('#brand-' + 0).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^(222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720|5018|50[2-3]|506|5[6-8]|5|603689|639|6220|67)/.test(number) && ids.includes("1")) { //mastercard
+      $brands.find('#brand-' + 1).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^(36|301|305|309|3[8-9])/.test(number) && ids.includes("2")) { //DINERS
+      $brands.find('#brand-' + 2).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^(40117[8-9]|431274|438935|451416|457393|45763[1-2]|504175|627780|636297|636368|506699|5067[0-6]|50677[0-8]|509|65003[1-3]|65003[5-9]|65004|65005[0-1]|65040[5-9]|6504[1-3]|65048[5-9]|65049|6505[0-2]|65053[0-8]|65054[1-9]|6505[5-8]|65059[0-8]|65070|65071[0-8]|65072[0-7]|65090[1-9]|65091|650920|65165[2-9]|6516[6-7]|6550[0-1]|65502[1-9]|6550[3-4]|65505[0-8]|65092[1-9]|6509[3-6]|65097[0-8])'/.test(number) && ids.includes("3")) { //ELO
+      $brands.find('#brand-' + 3).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^(34|37)/.test(number) && ids.includes("4")) { //AMEX
+      $brands.find('#brand-' + 4).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^(6011|62|64|65)/.test(number) && ids.includes("5")) { //DISCOVER
+      $brands.find('#brand-' + 5).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^50/.test(number) && ids.includes("6")) { //AURA
+      $brands.find('#brand-' + 6).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^35/.test(number) && ids.includes("7")) { //JCB
+      $brands.find('#brand-' + 7).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^(384100|384140|384160|60)/.test(number) && ids.includes("8")) { //HIPERCARD
+      $brands.find('#brand-' + 8).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^6033/.test(number) && ids.includes("11")) { //TICKET
+      $brands.find('#brand-' + 11).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (/^6026/.test(number) && ids.includes("11")) { //TICKET
+      $brands.find('#brand-' + 11).addClass('active').siblings().removeClass('active');
+      $('[name=cardNumber]').removeClass('alert');
+    } else if (number.length > 11) {
+      $brands.find('.active').removeClass('active');
+      $('[name=cardNumber]').addClass('alert');
+    }
   }
 
   var expirationSelector = '.payment_method_4all [name=expirationDate]';
@@ -27,7 +65,7 @@ var $ = jQuery;
     event.target.value = createMask(v);
   });
 
-  $context.on('keypress', cardNumberSelector, function (event) {
+  $context.on('keyup', cardNumberSelector, function (event) {
     var v = event.target.value;
     checkCardType(v, $('.form-row-brands'));
   });

--- a/assets/js/4all-scripts.js
+++ b/assets/js/4all-scripts.js
@@ -1,0 +1,35 @@
+var $ = jQuery;
+
+(function($) {
+  var $context = $('#order_review');
+
+  function createMask(string) {
+    return string.replace(/\D/g, '').replace(/(\d{2})(\d)/, '$1/$2').replace(/(\d{2})(\d)/, '$1/$2').replace(/(\d{2})(\d{2})$/, '$1$2');
+  }
+
+  function destroyMask(string) {
+    return string.replace(/\D/g, '').substring(0, 3);
+  }
+
+  function checkCardType(number, $brands) {
+
+
+    var id = 1;   
+
+    $brands.find('#brand-' + id).addClass('active').siblings().removeClass('active');
+  }
+
+  var expirationSelector = '.payment_method_4all [name=expirationDate]';
+  var cardNumberSelector = '.payment_method_4all [name=cardNumber]';
+
+  $context.on('keypress', expirationSelector, function(event) {
+    var v = destroyMask(event.target.value);
+    event.target.value = createMask(v);
+  });
+
+  $context.on('keypress', cardNumberSelector, function (event) {
+    var v = event.target.value;
+    checkCardType(v, $('.form-row-brands'));
+  });
+
+}(jQuery));

--- a/includes/class-woocommerce-4all.php
+++ b/includes/class-woocommerce-4all.php
@@ -42,39 +42,7 @@
       * Payment fields.
       */
       public function payment_fields() {
-        $gateway_4all = new woocommerce_4all_gateway($this->gatewaySettings);
-        $paymentMethods = $gateway_4all->getPaymentMethods();
-        $minInstallment = $paymentMethods['resume']['minInstallments'];
-        $maxInstallments = $paymentMethods['resume']['maxInstallments'];
-        
-        echo  '<p>Name of the buyer (same as the card)</p>';
-        echo  '<input type="text" name="cardholderName">';
-        echo  '<p>Card number</p>';
-        echo  '<input type="text" name="cardNumber">';
-        echo  '<p>Expiration date</p>';
-        echo  '<input type="text" placeholder="MM/YY" name="expirationDate">';
-        echo  '<p>Security code</p>';
-        echo  '<input type="text" name="securityCode">';
-        echo  '<p>Installment</p>';
-        echo '<select name="installment">';
-        for (;$minInstallment<=$maxInstallments;$minInstallment++) {
-          echo '<option value="'.$minInstallment.'">'.$minInstallment.'</option>';
-        }
-        echo '</select>';
-        echo '<script>';
-        echo '    document.querySelector(\'[name=expirationDate]\').addEventListener(\'keypress\', function(e) {';
-        echo '    var v = destroyMask(e.target.value);';
-        echo '        e.target.value = createMask(v);';
-        echo '    });';
-            
-        echo '    function createMask(string){';
-        echo "        return string.replace(/\D/g, '').replace(/(\d{2})(\d)/, '$1/$2').replace(/(\d{2})(\d)/, '$1/$2').replace(/(\d{2})(\d{2})$/, '$1$2');";
-        echo '    }';
-
-        echo '    function destroyMask(string){';
-        echo "        return string.replace(/\D/g,'').substring(0,3);";
-        echo '    }';
-        echo '</script>';
+        include('form-template.php');
       }
 
       public function validate_fields()

--- a/includes/class-woocommerce-4all.php
+++ b/includes/class-woocommerce-4all.php
@@ -219,8 +219,6 @@
 
         $metaData["customer"] = $this->add_customer();
 
-        die();
-
         $tryPay = $gateway_4all->paymentFlow($metaData);
 
         if ($tryPay["error"]) {

--- a/includes/class-woocommerce-4all.php
+++ b/includes/class-woocommerce-4all.php
@@ -219,6 +219,8 @@
 
         $metaData["customer"] = $this->add_customer();
 
+        die();
+
         $tryPay = $gateway_4all->paymentFlow($metaData);
 
         if ($tryPay["error"]) {

--- a/includes/form-template.php
+++ b/includes/form-template.php
@@ -3,29 +3,34 @@
 
   $gateway_4all = new woocommerce_4all_gateway($this->gatewaySettings);
   $paymentMethods = $gateway_4all->getPaymentMethods();
+  $nonePaymentMethods = true; //variavel para o caso do merchant ainda nao ter nenhuma affiliation cadastrada
 
-  $brandsList = [];
+  if ($paymentMethods) {
+    $brandsList = [];
 
-  $brands = [
-    "https://4all.com/brands/visa.png", 
-    "https://4all.com/brands/mastercard.png",
-    "https://4all.com/brands/diners.png", 
-    "https://4all.com/brands/elo.png", 
-    "https://4all.com/brands/amex.png", 
-    "https://4all.com/brands/discover.png", 
-    "https://4all.com/brands/aura.png", 
-    "https://4all.com/brands/jcb.png", 
-    "https://4all.com/brands/hipercard.png", 
-    "https://4all.com/brands/maestro.png", 
-    "https://4all.com/brands/4-all.png", 
-    "https://4all.com/brands/ticket.png"
-  ];
+    //a ordem das imagens esta de acordo com os id's retornados do gateway correspondendo a imagem
+    $brands = [
+      "https://4all.com/brands/visa.png", 
+      "https://4all.com/brands/mastercard.png",
+      "https://4all.com/brands/diners.png", 
+      "https://4all.com/brands/elo.png", 
+      "https://4all.com/brands/amex.png", 
+      "https://4all.com/brands/discover.png", 
+      "https://4all.com/brands/aura.png", 
+      "https://4all.com/brands/jcb.png", 
+      "https://4all.com/brands/hipercard.png"
+    ];
 
-  for ($i=0; $i < sizeof($paymentMethods["brands"]); $i++) { 
-    array_push($brandsList, $paymentMethods["brands"][$i]["brandId"]);
+    for ($i=0; $i < sizeof($paymentMethods["brands"]); $i++) { 
+      //o -1 é necessario, pois o gateway retorna os id's de 1 para cima
+      array_push($brandsList, $paymentMethods["brands"][$i]["brandId"] -1);
+    }
+
+    $brandsListString = implode(";", $brandsList);
+  } else {
+    $nonePaymentMethods = true;
   }
 
-  $brandsListString = implode(";", $brandsList);
 ?>
 
 <p class="form-row">
@@ -34,13 +39,17 @@
 </p>
 <p class="form-row">
   <label>Card number</label>
-  <input type="text" name="cardNumber" maxlength="200">
+  <input type="text" name="cardNumber" maxlength="200" <?php if ($nonePaymentMethods) { echo 'class="disabled" disabled'; } ?>>
 </p>
 <input type="hidden" id="brandsList" value="<?php echo $brandsListString; ?>">
 <div class='form-row-brands'>
   <?php 
-    for ($i=0; $i < sizeof($brandsList); $i++) { 
-      echo '<img src="' . $brands[$brandsList[$i]] . '" id="brand-' . $brandsList[$i] . '" class="">';
+    if (!$nonePaymentMethods) {
+      for ($i=0; $i < sizeof($brandsList); $i++) { 
+        echo '<img src="' . $brands[$brandsList[$i]] . '" id="brand-' . $brandsList[$i] . '" class="">';
+      }
+    } else {
+      echo '<p>Não há formas de pagamento disponíveis</p>';
     }
   ?>
 </div>

--- a/includes/form-template.php
+++ b/includes/form-template.php
@@ -24,6 +24,8 @@
   for ($i=0; $i < sizeof($paymentMethods["brands"]); $i++) { 
     array_push($brandsList, $paymentMethods["brands"][$i]["brandId"]);
   }
+
+  $brandsListString = implode(";", $brandsList);
 ?>
 
 <p class="form-row">
@@ -34,10 +36,11 @@
   <label>Card number</label>
   <input type="text" name="cardNumber" maxlength="200">
 </p>
+<input type="hidden" id="brandsList" value="<?php echo $brandsListString; ?>">
 <div class='form-row-brands'>
   <?php 
     for ($i=0; $i < sizeof($brandsList); $i++) { 
-      echo '<img src="' . $brands[$i] . '" id="brand-' . $i . '" class="">';
+      echo '<img src="' . $brands[$brandsList[$i]] . '" id="brand-' . $brandsList[$i] . '" class="">';
     }
   ?>
 </div>

--- a/includes/form-template.php
+++ b/includes/form-template.php
@@ -1,0 +1,67 @@
+<?php 
+  include_once 'woocommerce-4all-gateway.php';
+
+  $gateway_4all = new woocommerce_4all_gateway($this->gatewaySettings);
+  $paymentMethods = $gateway_4all->getPaymentMethods();
+
+  $brandsList = [];
+
+  $brands = [
+    "https://4all.com/brands/visa.png", 
+    "https://4all.com/brands/mastercard.png",
+    "https://4all.com/brands/diners.png", 
+    "https://4all.com/brands/elo.png", 
+    "https://4all.com/brands/amex.png", 
+    "https://4all.com/brands/discover.png", 
+    "https://4all.com/brands/aura.png", 
+    "https://4all.com/brands/jcb.png", 
+    "https://4all.com/brands/hipercard.png", 
+    "https://4all.com/brands/maestro.png", 
+    "https://4all.com/brands/4-all.png", 
+    "https://4all.com/brands/ticket.png"
+  ];
+
+  for ($i=0; $i < sizeof($paymentMethods["brands"]); $i++) { 
+    array_push($brandsList, $paymentMethods["brands"][$i]["brandId"]);
+  }
+?>
+
+<p class="form-row">
+  <label>Name of the buyer (same as the card)</label>
+  <input type="text" name="cardholderName" maxlength="200">
+</p>
+<p class="form-row">
+  <label>Card number</label>
+  <input type="text" name="cardNumber" maxlength="200">
+</p>
+<div class='form-row-brands'>
+  <?php 
+    for ($i=0; $i < sizeof($brandsList); $i++) { 
+      echo '<img src="' . $brands[$i] . '" id="brand-' . $i . '" class="">';
+    }
+  ?>
+</div>
+<p class="form-row">
+  <label>Expiration date</label>
+  <input type="text" placeholder="MM/YY" name="expirationDate" maxlength="200">
+</p>
+<p class="form-row">
+  <label>Security code</label>
+  <input type="text" name="securityCode" maxlength="200">
+</p>
+
+<p class="form-row form-row-installment">
+  <label>Installment</label>
+  <select name="installment">
+
+  <?php
+    $minInstallment = $paymentMethods['resume']['minInstallments'];
+    $maxInstallments = $paymentMethods['resume']['maxInstallments'];
+    
+    for (;$minInstallment<=$maxInstallments;$minInstallment++) {
+      echo '<option value="'.$minInstallment.'">'.$minInstallment.'</option>';
+    }
+
+  ?>
+  </select>
+</p>

--- a/includes/form-template.php
+++ b/includes/form-template.php
@@ -49,7 +49,7 @@
         echo '<img src="' . $brands[$brandsList[$i]] . '" id="brand-' . $brandsList[$i] . '" class="">';
       }
     } else {
-      echo '<p>Não há formas de pagamento disponíveis</p>';
+      echo '<p>Não há formas de pagamento cadastrados</p>';
     }
   ?>
 </div>

--- a/woocommerce-4all.php
+++ b/woocommerce-4all.php
@@ -48,5 +48,22 @@
     $methods[] = 'WC_Gateway_4all';
     return $methods;
   }
+
+  function woocommerce_4all_add_css() {
+    $basePluginName = plugin_basename(plugin_dir_path( __FILE__ ));
+    $styleUrl = plugins_url( $basePluginName . '/assets/css/frontend/4all-style.css');
+    wp_enqueue_style( 'woocommerce_4all_style', $styleUrl);
+  }
   
+  function woocommerce_4all_add_js() {
+    $basePluginName = plugin_basename(plugin_dir_path( __FILE__ ));
+    $scriptUrl = plugins_url( $basePluginName . '/assets/js/4all-scripts.js');
+    $cards = plugins_url( $basePluginName . '/assets/js/4all-credit-cards.js');
+    wp_enqueue_script( 'woocommerce_4all_script', $scriptUrl, array('jquery'));
+    wp_enqueue_script( 'woocommerce_4all_credit_cards', $cards, array('woocommerce_4all_script'));
+  }
+
+  add_action( 'wp_enqueue_scripts', 'woocommerce_4all_add_css' );
+  add_action( 'wp_footer', 'woocommerce_4all_add_js' );
+
   add_filter('woocommerce_payment_gateways', 'woocommerce_4all_add_gateway');


### PR DESCRIPTION
Adicionadas bandeiras a baixo do campo do cartão. O plugin busca as bandeiras que o EC aceita e o reconhece o cartão que o usuário digitou e acende a bandeira escolhida abaixo do campo, caso o cartão não seja válido, o campo ficará em vermelho mostrando que o cartão não é aceito. Caso o EC não tenha nenhuma bandeira aceita, o campo vai ficar bloqueado com um aviso de que ainda não há metodos de pagamentos cadastrados para esse EC.

Foram feitas também várias mudanças arquiteturais separando melhor o código e deixando mais organizado.